### PR TITLE
loosen rest client version dep

### DIFF
--- a/foreman_api_client.gemspec
+++ b/foreman_api_client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "apipie-bindings", "= 0.0.15"
-  spec.add_runtime_dependency "rest-client",     ">= 2.0.0.rc1"
+  spec.add_runtime_dependency "rest-client",     "~> 2.0"
 
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I thought Brandon said we shouldn't use rcs in these anyway ... and also I think we prefer having '2.0' vs '2.0.0'

We can't use https://github.com/ManageIQ/azure-armrest/pull/395 unless this gets changed. There's possibly a few others. 

also it'd be great if we updated `apipie-bindings` too but that's not necessary 