### PR TITLE
drop sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 - "2.6"
 - ruby-head
 - jruby-head
-sudo: false
 cache: bundler
 after_script: bundle exec codeclimate-test-reporter
 matrix:


### PR DESCRIPTION
we can get rid of `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration