### PR TITLE
Support setting `ssl_ca_file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ And then execute:
 require 'foreman_api_client'
 ForemanApiClient.logger = Logger.new(STDOUT)
 connection = ForemanApiClient::Connection.new(
-  :base_url   => base_url,
-  :username   => username,
-  :password   => password,
-  :verify_ssl => verify_ssl
+  base_url:    'https://foreman.example.com',
+  username:    'API_USER',
+  password:    'API_PASSWORD',
+  verify_ssl:  true, # optional: Defaults to `true`
+  ssl_ca_file: '/path/to/ssl_ca_file.pem', # optional: Path to CA certificate file.
 )
 c.host(1)
 => #<ForemanApiClient::Host:0x0055b8a05daa58 ...>

--- a/lib/foreman_api_client/connection.rb
+++ b/lib/foreman_api_client/connection.rb
@@ -10,7 +10,10 @@ module ForemanApiClient
       connection_attrs[:uri] = connection_attrs.delete(:base_url)
       connection_attrs[:api_version] ||= 2
       connection_attrs[:apidoc_cache_dir] ||= tmpdir
-      options = {:verify_ssl => connection_attrs.delete(:verify_ssl)}
+      options = {
+        verify_ssl:  connection_attrs.delete(:verify_ssl),
+        ssl_ca_file: connection_attrs.delete(:ssl_ca_file)
+      }.compact
       @api = ApipieBindings::API.new(connection_attrs, options)
     end
 


### PR DESCRIPTION
Useful if your foreman/puppet CA certificate isn't installed in your ruby's trusted certificate store and you prefer not to ignore the issue by setting `verify_ssl` to `false`.

@miq-bot add-label enhancement